### PR TITLE
Possible to fold tree nodes with level gt arg-defined depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ yarn add hexo-markmap
 
 # 使用
 ```
+{% markmap height [depth] %}
+```
+
+## 参数
+- `height`: 画布高度
+- `depth`: 可选，自动折叠层数深于`depth`的节点
+
+# 示例
+```
 {% markmap 300px %}
 - Testa
   - test1

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,7 +25,16 @@ or
 yarn add hexo-markmap
 ```
 
-# Usage 
+# Usage
+```
+{% markmap height [depth] %}
+```
+
+## Options
+- `height`: mindmap canvas height
+- `depth`: optional, when specified, automatically fold nodes with level greater than `depth`
+
+# Example 
 ```
 {% markmap 300px %}
 # Testa

--- a/index.js
+++ b/index.js
@@ -1,8 +1,30 @@
 const  { transfer } = require("./lib/transfer.js");
+const { walkTree } = require("markmap-common");
+
+
+function fold(tree, maxDepth = 0) {
+  if (
+    typeof maxDepth === 'undefined' ||
+    typeof parseInt(maxDepth) !== 'number' ||
+    maxDepth <= 0
+  ) {
+    return
+  }
+  maxDepth = parseInt(maxDepth)
+  walkTree(tree, (node, next) => {
+    // Here depths are in sequence of [0, 2, 4, ..., 2n]
+    if (node.d >= maxDepth * 2) {
+      node.p = Object.assign(node.p, { f: true });
+    }
+    next();
+  })
+}
+
 
 hexo.extend.tag.register("markmap", function (args, content) {
   const { svgData } = transfer(content.trim());
-  const [ height ] = args
+  const [ height, displayDepth ] = args;
+  fold(svgData, displayDepth)
   return `
     <div class="markmap-container" style="height:${height}">
       <svg data='${JSON.stringify(svgData)}'></svg>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "MaxChang3",
   "license": "MIT",
   "dependencies": {
+    "markmap-common": "^0.1.6",
     "markmap-lib": "^0.11.6"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,6 +42,13 @@ markmap-common@^0.1.5:
   dependencies:
     "@babel/runtime" "^7.12.1"
 
+markmap-common@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/markmap-common/-/markmap-common-0.1.6.tgz#11050562c23ae84b160e01e663478f29f1dd9ae6"
+  integrity sha512-fx4YUo6gZFFr08mi8qX8i6RH9xm5yieLKHr9hAdaTMP+CkPmgzB65F/+t39aFH5HcyEgs5vtTrRZ40lkhalETA==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+
 markmap-lib@^0.11.6:
   version "0.11.6"
   resolved "https://registry.nlark.com/markmap-lib/download/markmap-lib-0.11.6.tgz#f57883f9b70350ead94ed2d56926166b6d7ab2ef"


### PR DESCRIPTION
### Description
It would be nice to display only high-level nodes at first glance, as rendering all nodes of a large mind map often makes its text unreadable.

### Implementation
- re-walk markmap tree and add `{f: true}` to the payload of nodes deeper than a given `maxDepth` (inspired by https://github.com/gera2ld/markmap/issues/38#issuecomment-809164582)
- expose this `maxDepth` as an optional argument (the second argument) in `{% markmap %}` tag
- note that user-specified root is at level 1 whereas fake root added when no root specified is at level 0

### Test
##### Mind map n°1:
```
- 1
  - 2
    - 3
      - 4
        - 5
```
1. code below should display all 5 nodes
```
{% markmap 120px %}
- 1
  - 2
    - 3
      - 4
        - 5
{% endmarkmap %}
```
2. code below should display all 5 nodes
```
{% markmap 120px 0 %}
- 1
  - 2
    - 3
      - 4
        - 5
{% endmarkmap %}
```
3. code below should display all 5 nodes
```
{% markmap 120px -10 %}
- 1
  - 2
    - 3
      - 4
        - 5
{% endmarkmap %}
```
4. code below should display nodes 1 and 2
```
{% markmap 120px 2 %}
- 1
  - 2
    - 3
      - 4
        - 5
{% endmarkmap %}
```
<img width="341" alt="image" src="https://user-images.githubusercontent.com/4461484/162713343-0bdc01e6-9fbd-4ec0-8485-f8ab29ba8420.png">

##### Mind map n°2:
```
- 1.1
  - 2.1
    - 3.1
      - 4.1
        - 5.1
- 1.2
  - 2.2
    - 3.2
      - 4.2
        - 5.2
```
1. code below should display a fake root and nodes 1.1, 1.2, 2.1 and 2.2:
```
{% markmap 120px 2 %}
- 1.1
  - 2.1
    - 3.1
      - 4.1
        - 5.1
- 1.2
  - 2.2
    - 3.2
      - 4.2
        - 5.2
{% endmarkmap %}
```
<img width="550" alt="image" src="https://user-images.githubusercontent.com/4461484/162713419-17bd996c-30a8-461b-b203-d2738d8c512d.png">


A live demo with `{% markmap 640px 2 %}` [here](https://yhuang.pro/2022/04/09/syn-2015-google-large-scale-cluster-management-at-google-with-borg/)