### PR TITLE
refactor: refactor pjaxInit module and add allow theme_config.pjax to enable pjaxInit

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,19 +10,17 @@ const getInnerData = ()=> {
   const normalInit = `<script>document.querySelectorAll('.markmap-container>svg').forEach(mindmap => markmap.Markmap.create(mindmap, null, JSON.parse(mindmap.getAttribute('data'))))</script>`
   const pjaxInit = `
     <script>
-    function initMarkMap() {
-      document.querySelectorAll('.markmap-container>svg').forEach(mindmap => markmap.Markmap.create(mindmap, null, JSON.parse(mindmap.getAttribute('data'))))
-    }
-    initMarkMap()
-    let pushState = history.pushState
-    history.pushState = function () {
-      pushState.apply(history, arguments)
-      // re-init markmap after history.pushState invoking
+      function initMarkMap() {
+        document.querySelectorAll('.markmap-container>svg').forEach(mindmap => markmap.Markmap.create(mindmap, null, JSON.parse(mindmap.getAttribute('data'))))
+      }
       initMarkMap()
-    }
+      document.addEventListener("pjax:complete",()=>{            
+        window.initMarkMap()
+      })
     </script>
   `
-  return addonScript + ((config?.hexo_markmap?.pjax) ? pjaxInit : normalInit)
+  const isPjax = (config.hexo_markmap && config.hexo_markmap.pjax) || config.theme_config.pjax || false
+  return addonScript + (isPjax?pjaxInit:normalInit)
 }
 
 hexo.extend.tag.register("markmap", function (args, content) {


### PR DESCRIPTION
更新如下：
1. 通过 `pjax:complete` 事件来重新初始化，原方式在多文章情况下会被套娃，代码不优雅
2. 如果 hexo 配置中没有 pjax 配置时，可以通过主题下的 pjax 来控制 pjax 初始化
3. 移除选择运算符，更通用些，它在我的电脑上会报错。
4. 修复优先级导致的二元运算错误