### PR TITLE
perf: 适配 pjax 更新

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,39 @@
-const { Transformer } = require('markmap-lib');
-const { mainTemplate, containerTemplate, afterRender } = require("./lib/template");
-const { fold } = require("./lib/extension");
+const { Transformer } = require('markmap-lib')
+const {
+  mainTemplate,
+  containerTemplate,
+  afterRender
+} = require('./lib/template')
+const { fold } = require('./lib/extension')
 const { config } = hexo
-const transformer = new Transformer();
+const transformer = new Transformer()
 
-hexo.extend.tag.register("markmap", ([height, depth], markdown) => {
-  const { root: svgData } = transformer.transform(markdown);
-  return containerTemplate(fold(svgData, depth), { height })
-}, { ends: true });
+hexo.extend.tag.register(
+  'markmap',
+  ([height, depth], markdown) => {
+    const { root: svgData } = transformer.transform(markdown)
+    return containerTemplate(fold(svgData, depth), { height })
+  },
+  { ends: true }
+)
 
 hexo.extend.filter.register('after_render:html', (content) =>
-  afterRender(content, mainTemplate({
-    pjaxEnable: config?.hexo_markmap?.pjax || config?.theme_config?.pjax,
-    katexEnable: config?.hexo_markmap?.katex,
-    prismEnable: config?.hexo_markmap?.prism,
-  },
-    config?.hexo_markmap?.CDN
-  ))
+  // 可选操作符不支持 nodejs 14 以下，改成通用
+  afterRender(
+    content,
+    mainTemplate(
+      {
+        katexEnable:
+          config && config.hexo_markmap && config.hexo_markmap.katex
+            ? true
+            : false,
+        prismEnable:
+          config && config.hexo_markmap && config.hexo_markmap.prism
+            ? true
+            : false
+      }
+      // 使用着不应知道要用哪些包，而应给他们选择需要什么功能
+      // config?.hexo_markmap?.CDN
+    )
+  )
 )

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,40 +1,140 @@
-const CDN = {
-  d3_js: "https://fastly.jsdelivr.net/npm/d3@6",
-  markmap_view_js: "https://fastly.jsdelivr.net/npm/markmap-view@0.2.7",
-  katex_css: "https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css",
-  prism_css: "https://fastly.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css"
+const mainTemplate = ({ katexEnable, prismEnable })=> {  
+  const scripts = `
+  // 使用闭包，防止污染全局
+function loadMarkmap()
+{
+  // 初始化markmap
+  function initMarkmap(){
+    const sources = [
+      {
+        type:'css_text',
+        enable: true,
+        value: '.markmap-container{display:flex;justify-content:center;margin:0 auto;width:90%;height:500px}.markmap-container svg{width:100%;height:100%}@media(max-width:768px){.markmap-container{height:400px}}',
+      },
+      {
+        type: 'css_src',
+        value: 'https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css',
+        enable: ${katexEnable}
+      },
+      {
+        type: 'css_src',
+        value: 'https://fastly.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css',
+        enable: ${prismEnable}
+      },
+      {
+        type: 'js_src',
+        value: 'https://cdn.jsdelivr.net/npm/d3@6',
+        enable: true
+      },
+      {
+        type: 'js_src',
+        value: 'https://cdn.jsdelivr.net/npm/markmap-view@0.2.7',
+        enable: true
+      }
+    ]
+      
+    // 判断是否有markmap
+    const markupContainers = document.querySelectorAll('.markmap-container>svg')
+  
+    // 说明没有脑图
+    if(markupContainers.length<1)return
+  
+    console.log('exist markmap,initializing...')
+    
+    // 说明已经加载
+    if(window.markmap){
+      // 直接初始化
+      crateMarkmap()
+      return
+    }
+  
+    // 加载所有的 css,js
+    const promiseArr = sources.filter(x=>x.enable)
+    .map(x=>{
+      switch(x.type){
+        case 'css_text':
+          return dynamicLoadCssText(x.value)
+        case 'css_src':
+          return dynamicLoadCssUrl(x.value)
+        case 'js_src':
+          return dynamicLoadJs(x.value)
+        default:
+          return null
+      }
+    }).filter(x=>x)
+
+    if(promiseArr && promiseArr.length>0)
+    {
+      // 脚本全部加载完成后再执行 markmap 初始化  
+      Promise.all(promiseArr).then(x=>{        
+        crateMarkmap()
+      })
+    }
+  }
+  
+  // 动态加载 js
+  function dynamicLoadJs(url){
+    const element = document.createElement('script')
+    element.setAttribute('type', 'text/javascript')
+    element.src = url
+    return dynamicLoadElement(element)
+  }
+  
+  // 动态加载文本型 css
+  function dynamicLoadCssText(cssText){
+    const element = document.createElement("style")
+    element.appendChild(document.createTextNode(cssText))
+    return dynamicLoadElement(element)
+  }
+  
+  // 动态加载 url 型 css
+  function dynamicLoadCssUrl(url){  
+    const element = document.createElement('link')
+    element.href = url
+    element.setAttribute('rel', 'stylesheet')
+    element.setAttribute('media', 'all')
+    element.setAttribute('type', 'text/css')
+    
+    return dynamicLoadElement(element)
+  }
+  
+  // 将创建的元素添加到 head 中
+  function dynamicLoadElement(element){
+    const promise = new Promise((resolve)=>{
+      const head = document.getElementsByTagName('head')[0]
+      if (element.readyState) {
+        element.onreadystatechange = () => {
+          if (element.readyState === 'loaded' || element.readyState === 'complete') {
+            element.onreadystatechange = null
+            resolve()
+          }
+        }
+      } else {
+        element.onload = resolve
+      }
+      head.appendChild(element)      
+    })
+  
+    return promise
+  }
+  
+  function crateMarkmap(){
+    const eles = document.querySelectorAll('.markmap-container>svg')
+    eles.forEach(mindmap => window.markmap.Markmap.create(mindmap, null, JSON.parse(mindmap.getAttribute('data'))))
+  }
+  
+  // 监听事件
+  document.addEventListener("pjax:complete",(arg)=>{
+    initMarkmap()
+  })
+  
+  initMarkmap()
 }
 
-const mainTemplate = ({ pjaxEnable, katexEnable, prismEnable }, userCDN) => `
-<script src="${userCDN?.d3_js || CDN.d3_js}"></script>
-<script src="${userCDN?.markmap_view_js || CDN.markmap_view_js}"></script>
-${katexEnable ? `<link rel="stylesheet" href="${userCDN?.katex_css || CDN.katex_css}">` : ""}
-${prismEnable ? `<link rel="stylesheet" href="${userCDN?.prism_css || CDN.prism_css}">` : ""}
-<style>
-.markmap-container{
-  display:flex;
-  justify-content:center;
-  margin:0 auto;
-  width:90%;
-  height:500px
+loadMarkmap()
+  `
+  return `<script>${scripts}</script>`
 }
-.markmap-container svg{
-  width:100%;height:100%
-}
-@media(max-width:768px){
-  .markmap-container{
-    height:400px
-  }
-}</style>
-<script>
-function initMarkMap(){
-  document.querySelectorAll('.markmap-container>svg').forEach(el =>{
-    markmap.Markmap.create(el, null, JSON.parse(el.getAttribute('data')))
-  })
-};
-initMarkMap();
-${pjaxEnable ? 'document.addEventListener("pjax:complete",initMarkMap)' : ''}
-</script>`
 
 const containerTemplate = (svgData, { height }) => `
 <div class="markmap-container" style="height:${height}">


### PR DESCRIPTION
更新内容：
1. 将所有的资源改成动态加载
2. 在加载资源前，会判断是否有 markmap 项，有的话才加载资源
3. 取消了 pajax 选项，代码自动适配 pajax 打开了的情况（当没有 pajax 时，每次跳转页面会进行加载，当有 pajax 时，会触发 `pjax:complete` 事件，在这个事件中处理加载，因此，没有 pajax，就不会有事件）

其它：
1. 个人认为 CDN 不是有必要，可以给用户一个配置，询问是否打开什么功能，而不是让用户去找 CDN 地址来加载
2. index 注释了 CDN，如果需要启用，还需要适配下