### PR TITLE
feat: add option to lock markmap view

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ hexo_markmap:
 If your blog has pjax installed, please turn it on.
 
 ### KaTeX
+
 default value `false`
+
 ```yaml
 hexo_markmap:
   katex: true
@@ -93,7 +95,9 @@ If you need to use $K\kern-.25em\raise.45ex {\scriptstyle{A}}\kern-.15em\TeX$, p
 
 
 ### Prism
+
 default value `false`
+
 ```yaml
 hexo_markmap:
   prism: true
@@ -102,6 +106,7 @@ hexo_markmap:
 If you need to use code blocks, please turn it on to insert the CSS links. If prism.css has already been added to your blog by another way, then you don’t need to do it.
 
 ### Custom CDN
+
 ```yaml
 hexo_markmap:
   CDN:
@@ -109,6 +114,17 @@ hexo_markmap:
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css
     prism_css: https://fastly.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css
+```
+
+### Lock view
+
+default value `false`
+
+Disable the zoom and pan of the view. ()
+
+```yaml
+hexo_markmap:
+  lock: true
 ```
 
 ### default option
@@ -122,4 +138,5 @@ hexo_markmap:
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css
     prism_css: https://fastly.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css
+  lock: false
 ```

--- a/README_HANS.md
+++ b/README_HANS.md
@@ -79,7 +79,9 @@ hexo_markmap:
 如果你的博客安装了 pjax 请开启此项配置。
 
 ### KaTeX
+
 默认值 `false`
+
 ```yaml
 hexo_markmap:
   katex: true
@@ -92,6 +94,7 @@ hexo_markmap:
 ### Prism
 
 默认值 `false`
+
 ```yaml
 hexo_markmap:
   prism: true
@@ -110,6 +113,17 @@ hexo_markmap:
     prism_css: https://fastly.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css
 ```
 
+### 锁定视图
+
+默认值 `false`
+
+关闭视图的放缩（zoom）、平移（pan）功能。
+
+```yaml
+hexo_markmap:
+  lockView: true
+```
+
 ### 缺省项
 
 ```yaml
@@ -122,4 +136,5 @@ hexo_markmap:
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css
     prism_css: https://fastly.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css
+  lockView: false
 ```

--- a/README_HANT.md
+++ b/README_HANT.md
@@ -79,7 +79,9 @@ hexo_markmap:
 如果你的部落格安裝了 pjax 請開啟此項配置。
 
 ### KaTeX
+
 預設值 `false`
+
 ```yaml
 hexo_markmap:
   katex: true
@@ -92,6 +94,7 @@ hexo_markmap:
 ### Prism
 
 預設值 `false`
+
 ```yaml
 hexo_markmap:
   prism: true
@@ -110,6 +113,17 @@ hexo_markmap:
     prism_css: https://fastly.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css
 ```
 
+### 鎖定檢視
+
+預設值 `false`
+
+關閉檢視的放縮（zoom）、平移（pan）功能。
+
+```yaml
+hexo_markmap:
+  lockView: true
+```
+
 ### 預設項
 
 ```yaml
@@ -122,4 +136,5 @@ hexo_markmap:
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css
     prism_css: https://fastly.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css
+  lockView: false
 ```

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ const options = {
   pjaxEnable: fget("hexo_markmap.pjax"),
   katexEnable: fget("hexo_markmap.katex"),
   prismEnable: fget("hexo_markmap.prism"),
-  userCDN: fget("hexo_markmap.userCDN")
+  userCDN: fget("hexo_markmap.userCDN"),
+  lockView: fget("hexo_markmap.lockView")
 }
 
 hexo.extend.tag.register('markmap', ([height, depth], markdown) => {

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,4 +1,4 @@
-const mainTemplate = ({ pjaxEnable, katexEnable, prismEnable, userCDN}) => `
+const mainTemplate = ({ pjaxEnable, katexEnable, prismEnable, userCDN, lockView }) => `
   const initMarkmap = async () => {
     const debounce = (callback, wait) => {
       let timeout;
@@ -20,6 +20,7 @@ const mainTemplate = ({ pjaxEnable, katexEnable, prismEnable, userCDN}) => `
         document.querySelectorAll('.markmap-container>svg').forEach(el => {
           let obj = markmap.Markmap.create(el, { autoFit: true }, JSON.parse(el.getAttribute('data')))
           autoFit(el, obj)
+          ${lockView ? `obj.svg.on('wheel.zoom', null).on('mousedown.zoom', null).on('touchstart.zoom', null)` : ''}
         })
     }
     if (window.markmap && Object.keys(window.markmap).length != 0) { createMarkmap(); return }
@@ -81,7 +82,7 @@ const afterRender = (content, html, { pjaxEnable }) => {
     const lastIndex = content.lastIndexOf('</body>')
     return content.substring(0, lastIndex) + html + content.substring(lastIndex, content.length)
   }
-  return content;
+  return content
 }
 
 module.exports = { mainTemplate, containerTemplate, scriptTemplate, afterRender }


### PR DESCRIPTION
Add a new option `lockView` to control the pan and zoom the markmap view.

I attempted to solve it by adding `pan: false` and `zoom: false` to `markmap.Markmap.create(el, options, json)`, but it did not work.  Maybe I will add a new option to inject options here in the future.

And then I find a solution by following https://github.com/markmap/markmap/issues/44.


resolve #44
