### PR TITLE
fix: cdn config not work and docs typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you need to use code blocks, please turn it on to insert the CSS links. If pr
 
 ```yaml
 hexo_markmap:
-  CDN:
+  userCDN:
     d3_js: https://fastly.jsdelivr.net/npm/d3@6
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css
@@ -133,7 +133,7 @@ hexo_markmap:
   pjax: false
   katex: false
   prism: false
-  CDN:
+  userCDN:
     d3_js: https://fastly.jsdelivr.net/npm/d3@6
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css

--- a/README_HANS.md
+++ b/README_HANS.md
@@ -106,7 +106,7 @@ hexo_markmap:
 
 ```yaml
 hexo_markmap:
-  CDN:
+  userCDN:
     d3_js: https://fastly.jsdelivr.net/npm/d3@6
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css
@@ -131,7 +131,7 @@ hexo_markmap:
   pjax: false
   katex: false
   prism: false
-  CDN:
+  userCDN:
     d3_js: https://fastly.jsdelivr.net/npm/d3@6
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css

--- a/README_HANT.md
+++ b/README_HANT.md
@@ -106,7 +106,7 @@ hexo_markmap:
 
 ```yaml
 hexo_markmap:
-  CDN:
+  userCDN:
     d3_js: https://fastly.jsdelivr.net/npm/d3@6
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css
@@ -131,7 +131,7 @@ hexo_markmap:
   pjax: false
   katex: false
   prism: false
-  CDN:
+  userCDN:
     d3_js: https://fastly.jsdelivr.net/npm/d3@6
     markmap_view_js: https://fastly.jsdelivr.net/npm/markmap-view@0.2.7
     katex_css: https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css

--- a/lib/template.js
+++ b/lib/template.js
@@ -26,8 +26,8 @@ const mainTemplate = ({ pjaxEnable, katexEnable, prismEnable, userCDN, lockView 
     if (window.markmap && Object.keys(window.markmap).length != 0) { createMarkmap(); return }
     const CDN = {
       "js": {
-        "d3": ${userCDN?.d3_js || "'https://fastly.jsdelivr.net/npm/d3@6',"}
-        "markmap_view": ${userCDN?.markmap_view_js || "'https://fastly.jsdelivr.net/npm/markmap-view@0.2.7',"}
+        "d3": "${userCDN?.d3_js || 'https://fastly.jsdelivr.net/npm/d3@6'}",
+        "markmap_view": "${userCDN?.markmap_view_js || 'https://fastly.jsdelivr.net/npm/markmap-view@0.2.7'}",
       },
       "css": [
         ${katexEnable ? `${userCDN?.katex_css || "'https://fastly.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css',"}` : ""}


### PR DESCRIPTION
1.  `_config.yml` 配置 `CDN` 路径不生效，修复逻辑bug
2.  文档与脚本不符，`CDN` 改为 `userCDN`